### PR TITLE
Add Gulp Stylelint scss Plugin

### DIFF
--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -1,0 +1,8 @@
+{
+  "extends": "stylelint-config-standard",
+  "rules": {
+    "indentation": "tab",
+    "number-leading-zero": null,
+    "unit-whitelist": ["em", "rem", "s"]
+  }
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,19 @@
+const gulp = require('gulp');
+
+
+// Default Task
+gulp.task('default', ['lint-scss']);
+
+gulp.task('lint-scss', function lintCssTask() {
+  const gulpStylelint = require('gulp-stylelint');
+ 
+  return gulp
+    .src('**/*.scss')
+    .pipe(gulpStylelint({
+      reporters: [
+        {formatter: 'string', console: true}
+      ],
+      debug: true
+    }));
+});
+

--- a/package.json
+++ b/package.json
@@ -23,13 +23,16 @@
   },
   "devDependencies": {
     "grunt": "~0.4.5",
-    "grunt-contrib-cssmin": "~0.10.0",
-    "grunt-contrib-concat": "~0.5.0",
+    "grunt-browser-sync": "~1.5.3",
     "grunt-contrib-compress": "~0.12.0",
+    "grunt-contrib-concat": "~0.5.0",
+    "grunt-contrib-cssmin": "~0.10.0",
     "grunt-contrib-imagemin": "~0.9.2",
     "grunt-contrib-sass": "~0.8.1",
     "grunt-contrib-uglify": "~0.6.0",
     "grunt-contrib-watch": "~0.6.1",
-    "grunt-browser-sync": "~1.5.3"
+    "gulp": "^3.9.1",
+    "gulp-stylelint": "^2.0.2",
+    "stylelint-config-standard": "^7.0.0"
   }
 }


### PR DESCRIPTION
#26 
This commit adds the Gulp and Stylelint dependency parameters in package.json, Sets up the configure files gulpfile.js (which is similar to Grunt's Gruntfile.js) and adds rules (I need help with this part). 

The default yml rule config provided by scss-lint is far more comprehensive that the basic .stylelintrc.yaml file in this commit. I was not able to find a one-to-one mapping for all the linting rules in the scss-lint yml config for the .stylelintrc.yaml file.

Currently on executing 'gulp' it produces some errors with CSS indentation and Syntax issues which may be due to the rules. 