### PR TITLE
Allow overriding configuration values

### DIFF
--- a/src/style/_gutenberg-config.scss
+++ b/src/style/_gutenberg-config.scss
@@ -1,10 +1,10 @@
 /* Configuration
    ========================================================================== */
 
-$edit-mode: true; // [ true / false ] - Enables/disables the grid toggle button.
+$edit-mode: true !default; // [ true / false ] - Enables/disables the grid toggle button.
 
 // Theme / Fonts
-$theme: Merriweather; // [ Merriweather / OpenSans / custom ]
+$theme: Merriweather !default; // [ Merriweather / OpenSans / custom ]
 $custom-font-body: null !default; // [ "Libre Baskerville", Georgia, serif ]
 $custom-font-headings: null !default;
 
@@ -14,9 +14,9 @@ $paragraph-indent: false; // [ true / false ]
 // Base sizes
 $base-font-size: 100 !default; // In %. Also used for mobile. Number only, no units.
 $base-font-size-desktop: 112.5 !default; // In %. Used to calculate the desktop font size. Number only, no units.
-$line-height: 1.625;
-$line-height-desktop: 1.7;
-$max-width: 35; // Number only, no units. Gets converted to REMs and pixels.
+$line-height: 1.625 !default;
+$line-height-desktop: 1.7 !default;
+$max-width: 35 !default; // Number only, no units. Gets converted to REMs and pixels.
 
 // Modular Scale
 $modular-scale: (
@@ -33,10 +33,10 @@ $modular-scale: (
 ) !default;
 
 // Colors
-$color-font-body: #222;
-$color-font-headings: $color-font-body;
-$color-font-light: #888;
-$color-font-figcaption: $color-font-body;
+$color-font-body: #222 !default;
+$color-font-headings: $color-font-body !default;
+$color-font-light: #888 !default;
+$color-font-figcaption: $color-font-body !default;
 
 /* Calculations
    ========================================================================== */


### PR DESCRIPTION
When incorporating Gutenberg in other projects, it is desirable to allow overriding values from the configuration. This avoids the need to fork and hand-edit the configuration files in most cases. For example, with this commit applied it's possible to use WebPack in the following way:

```sh
npm install --save-dev gutenberg-web-type  # Install the normal version
cat > main.scss <<EOF
$theme: custom;
$custom-font-body: Palatino, serif;
$custom-font-headings: Impact, sans-serif;
@import '~gutenberg-web-type/src/style/gutenberg';
EOF
webpack  # Assumes that WebPack is properly configured to use
         # sass-loader + resolve-url-loader on *.scss files.
```

Notice how this completely avoids modifying the copy of Gutenberg installed using NPM.