### PR TITLE
Add postcss linting for SCSS based on Primer Stylelint Config

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "stylelint-config-primer"
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -116,6 +116,24 @@ module.exports = function(grunt){
           livereload: true,
         }
       }
+    },
+    // Linting
+    postcss: {
+      scsslint: {
+        options: {
+          writeDest: false,
+          syntax: require('postcss-scss'),
+          processors: [
+            require('stylelint')(),
+            require('postcss-reporter')({ clearMessages: true })
+          ]
+        },
+        files: [{
+          expand: true,
+          cwd: 'src/style',
+          src: ['*.scss']
+        }]
+      },
     }
   });
 
@@ -127,6 +145,8 @@ module.exports = function(grunt){
   grunt.loadNpmTasks('grunt-contrib-sass');
   grunt.loadNpmTasks('grunt-browser-sync');
   grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-postcss');
 
   grunt.registerTask('default', [ 'browserSync', 'watch' ]);
+  grunt.registerTask('lint', [ 'postcss:scsslint' ]);
 };

--- a/package.json
+++ b/package.json
@@ -23,13 +23,19 @@
   },
   "devDependencies": {
     "grunt": "~0.4.5",
-    "grunt-contrib-cssmin": "~0.10.0",
-    "grunt-contrib-concat": "~0.5.0",
+    "grunt-browser-sync": "~1.5.3",
     "grunt-contrib-compress": "~0.12.0",
+    "grunt-contrib-concat": "~0.5.0",
+    "grunt-contrib-cssmin": "~0.10.0",
     "grunt-contrib-imagemin": "~0.9.2",
     "grunt-contrib-sass": "~0.8.1",
     "grunt-contrib-uglify": "~0.6.0",
     "grunt-contrib-watch": "~0.6.1",
-    "grunt-browser-sync": "~1.5.3"
+    "grunt-postcss": "^0.8.0",
+    "grunt-stylelint": "^0.6.0",
+    "postcss-reporter": "^1.4.1",
+    "postcss-scss": "^0.3.1",
+    "stylelint": "^7.3.1",
+    "stylelint-config-primer": "^1.2.0"
   }
 }


### PR DESCRIPTION
Using grunt lint, we are now linting the SCSS code using postcss and a SCSS postcss processor. The linter configuration is based on Github's Primer Stylelint Config, available: https://github.com/primer/stylelint-config-primer

fixes #26