### PR TITLE
Remove `position: relative` from `<em>` and `<i>` in accordance with #74

### DIFF
--- a/src/style/modules/_text.scss
+++ b/src/style/modules/_text.scss
@@ -27,7 +27,6 @@ dfn {
 em,
 i {
   line-height: 0;
-  position: relative;
   vertical-align: baseline;
 }
 


### PR DESCRIPTION
https://github.com/matejlatin/Gutenberg/issues/74