### PR TITLE
Wrap scss division in calc()

### DIFF
--- a/src/style/_gutenberg-config.scss
+++ b/src/style/_gutenberg-config.scss
@@ -42,14 +42,14 @@ $color-font-figcaption: $color-font-body !default;
    ========================================================================== */
 
 // Mobile base & leading
-$base: 16 * ($base-font-size / 100);
+$base: 16 * calc($base-font-size / 100);
 $leading: round($base * $line-height);
-$leading-rem: $leading / $base;
+$leading-rem: calc($leading / $base);
 
 // Desktop base & leading
-$base-desktop: 16 * ($base-font-size-desktop / 100);
+$base-desktop: 16 * calc($base-font-size-desktop / 100);
 $leading-desktop: round($base-desktop * $line-height-desktop);
-$leading-rem-desktop: $leading-desktop / $base-desktop;
+$leading-rem-desktop: calc($leading-desktop / $base-desktop);
 
 /* Font themes
    ========================================================================== */

--- a/src/style/layout/_base.scss
+++ b/src/style/layout/_base.scss
@@ -24,7 +24,7 @@ html {
 
   @media screen and (min-width: #{ $max-width + 5 + 'em'}) {
     font-size: #{$base-desktop + 'px'};
-    font-size: #{$base-font-size-desktop / 100 + 'rem'};
+    font-size: #{calc($base-font-size-desktop / 100) + 'rem'};
   }
 
 }


### PR DESCRIPTION
Fixes #84

(deprecation warnings for division operator—breaking change being implemented to Sass, see here for more: https://sass-lang.com/documentation/breaking-changes/slash-div)